### PR TITLE
feat: minijuego de ingredientes horizontal

### DIFF
--- a/sandagamejam/i18n/menu_labels.json
+++ b/sandagamejam/i18n/menu_labels.json
@@ -18,7 +18,8 @@
 				"time_up": "¡Tiempo!",
 				"game_over": "¡Ay no! :(",
 			},
-			"play_again": "Volver a jugar"
+			"play_again": "Volver a jugar",
+			"back_to_menu": "Menú principal"
 		},
 	"en":
 		{
@@ -39,7 +40,8 @@
 				"time_up": "Time's up!",
 				"game_over": "Oh no! :(",
 			},
-			"play_again": "Play again"
+			"play_again": "Play again",
+			"back_to_menu": "Main menu"
 		},
 	"fr":
 		{
@@ -60,6 +62,7 @@
 				"time_up": "Trop!",
 				"game_over": "Oh non :("
 			},
-			"play_again": "Rejouer"
+			"play_again": "Rejouer",
+			"back_to_menu": "Menu principal"
 		}
 }

--- a/sandagamejam/project.godot
+++ b/sandagamejam/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="SandaGameJam"
 run/main_scene="uid://bcx0u2eaelyr6"
-config/features=PackedStringArray("4.4", "GL Compatibility")
+config/features=PackedStringArray("4.5", "GL Compatibility")
 config/icon="res://icon.svg"
 
 [autoload]

--- a/sandagamejam/scenes/menus/intro.tscn
+++ b/sandagamejam/scenes/menus/intro.tscn
@@ -46,3 +46,14 @@ offset_right = 719.0
 offset_bottom = 560.0
 scale = Vector2(1.2, 1.2)
 texture_normal = ExtResource("5_uh46f")
+
+[node name="OmitIntro" type="Button" parent="."]
+offset_left = 1000.0
+offset_top = 20.0
+offset_right = 1140.0
+offset_bottom = 55.0
+theme_override_font_sizes/font_size = 16
+text = "Omitir intro >"
+flat = true
+
+[connection signal="pressed" from="OmitIntro" to="." method="_on_omit_intro_pressed"]

--- a/sandagamejam/scenes/ui/FinalScreen.tscn
+++ b/sandagamejam/scenes/ui/FinalScreen.tscn
@@ -430,4 +430,35 @@ text = "Volver a jugar"
 label_settings = ExtResource("10_kmylr")
 horizontal_alignment = 1
 
+[node name="BtnBackToMenu" type="TextureButton" parent="."]
+visible = false
+z_index = 3
+layout_mode = 2
+offset_left = 461.0
+offset_top = 590.0
+offset_right = 708.0
+offset_bottom = 666.0
+size_flags_horizontal = 0
+texture_normal = ExtResource("7_3v14m")
+texture_pressed = ExtResource("8_nsh0p")
+texture_disabled = ExtResource("9_l1772")
+
+[node name="Label" type="Label" parent="BtnBackToMenu"]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -78.0
+offset_top = -15.0
+offset_right = 78.0
+offset_bottom = 15.0
+grow_horizontal = 2
+grow_vertical = 2
+text = "Menú principal"
+label_settings = ExtResource("10_kmylr")
+horizontal_alignment = 1
+
 [connection signal="pressed" from="BtnPlayAgain" to="." method="_on_btn_play_again_pressed"]
+[connection signal="pressed" from="BtnBackToMenu" to="." method="_on_btn_back_to_menu_pressed"]

--- a/sandagamejam/scenes/ui/SplashScreen.tscn
+++ b/sandagamejam/scenes/ui/SplashScreen.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=3 format=3 uid="uid://bcx0u2eaelyr6"]
 
 [ext_resource type="Script" uid="uid://dh3kgjq1etv3p" path="res://scripts/ui/splash_screen.gd" id="1_7fm2c"]
-[ext_resource type="Texture2D" uid="uid://b67j32dky2rn8" path="res://assets/backgrounds/splash.png" id="2_tnnoe"]
+[ext_resource type="Texture2D" uid="uid://c8jn053y1hnk" path="res://assets/backgrounds/splash.png" id="2_tnnoe"]
 
 [node name="SplashScreen" type="Control"]
 layout_mode = 3

--- a/sandagamejam/scripts/game_controller.gd
+++ b/sandagamejam/scripts/game_controller.gd
@@ -133,9 +133,12 @@ func slide_minigame_overlay(path: String):
 
 	if minigame_instance.has_signal("ingredients_minigame_started"):
 		minigame_instance.connect("ingredients_minigame_started", Callable(self, "_on_overlay_minigame_started"))
-		
+
 	if minigame_instance.has_signal("ingredients_minigame_timeout"):
 		minigame_instance.connect("ingredients_minigame_timeout", Callable(self, "_on_overlay_minigame_timeout"))
+
+	if minigame_instance.has_signal("recipe_selected"):
+		minigame_instance.connect("recipe_selected", Callable(self, "_on_recipe_selected"))
 
 	self.current_minigame = minigame_instance
 	
@@ -391,6 +394,7 @@ func reset_game():
 	
 # Senales
 func _on_ingredients_minigame_timeout():
+	print("⚠️ EJECUTANDO _on_ingredients_minigame_timeout")
 	# Obtener los resultados
 	var result = check_recipe()
 	
@@ -452,8 +456,27 @@ func _on_overlay_minigame_started():
 	emit_signal("ingredients_minigame_started")
 
 func _on_overlay_minigame_timeout():
+	print("⚠️ TIMEOUT desde OVERLAY")
 	emit_signal("ingredients_minigame_timeout")
 	_on_ingredients_minigame_timeout() # sigue llamando tu lógica actual
+
+func _on_recipe_selected(recipe_data: Dictionary, ingredients_array: Array) -> void:
+	# Cerrar el overlay y restaurar el nivel
+	finish_minigame()
+
+	# Iniciar ingredientes en el nivel principal
+	if current_level and current_level.has_method("start_ingredients_on_table"):
+		current_level.start_ingredients_on_table(recipe_data, ingredients_array)
+
+		# Conectar timeout del nivel si tiene la señal
+		if current_level.has_signal("ingredients_timeout") and not current_level.is_connected("ingredients_timeout", Callable(self, "_on_level_ingredients_timeout")):
+			current_level.connect("ingredients_timeout", Callable(self, "_on_level_ingredients_timeout"))
+
+func _on_level_ingredients_timeout() -> void:
+	print("⚠️ TIMEOUT desde NIVEL")
+	# Cuando los ingredientes del nivel terminan
+	emit_signal("ingredients_minigame_timeout")
+	_on_ingredients_minigame_timeout()
 
 func _prepare_final(state: GlobalManager.GameState):
 	print("preparing... ", state )

--- a/sandagamejam/scripts/intro.gd
+++ b/sandagamejam/scripts/intro.gd
@@ -3,7 +3,7 @@ extends Node2D
 @onready var btn_start: TextureButton = $Comenzar_Game
 @onready var text_intro: Label = $TextureRect/text_intro
 @onready var btn_back: Button = $BtnBack if has_node("BtnBack") else null 
-@onready var lbl_omit_intro: Label = $OmitIntro
+@onready var btn_omit_intro: Button = $OmitIntro
 
 
 var json_texts = {
@@ -32,6 +32,11 @@ var json_texts = {
 
 var texts = []
 var typing_speed := 0.05
+var skip_labels = {
+	"es": "Omitir intro >",
+	"en": "Skip intro >",
+	"fr": "Passer l'intro >"
+}
 var typing_timer: Timer
 var full_text := ""
 var char_index := 0
@@ -46,9 +51,13 @@ func _ready():
 	typing_timer.one_shot = false
 	typing_timer.timeout.connect(Callable(self, "_on_typing_timeout"))
 	add_child(typing_timer)
-	
+
 	_show_text(texts[current_index])
-	
+
+	# Configurar texto del botón omitir según idioma
+	if btn_omit_intro:
+		btn_omit_intro.text = skip_labels.get(GlobalManager.game_language, skip_labels["es"])
+
 	btn_start.pressed.connect(_on_btn_start_pressed)
 	if has_node("BtnBack"):
 		btn_back.pressed.connect(_on_btn_back_pressed)
@@ -91,11 +100,7 @@ func _on_btn_back_pressed():
 	AudioManager.play_click_sfx()
 	get_tree().change_scene_to_file("res://scenes/menus/MainMenu.tscn")
 
-func _input(event):
-	if lbl_omit_intro and lbl_omit_intro.get_global_rect().has_point(get_viewport().get_mouse_position()):
-		if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:_skip_intro()
-
-func _skip_intro():
+func _on_omit_intro_pressed():
 	AudioManager.play_click_sfx()
 	var level_1_path = "res://scenes/levels/PastryLevel1.tscn"
 	GlobalManager.start_game()

--- a/sandagamejam/scripts/levels/minigame_overlay.gd
+++ b/sandagamejam/scripts/levels/minigame_overlay.gd
@@ -3,6 +3,7 @@ extends Node2D
 
 signal ingredients_minigame_started
 signal ingredients_minigame_timeout
+signal recipe_selected(recipe_data: Dictionary, ingredients_array: Array)
 
 @onready var menu_container : Control = $TextureRect/MenuContainer
 @onready var recipe_container : Control = $TextureRect/RecipeContainer
@@ -38,6 +39,10 @@ func hide_recollect_container():
 
 func show_recollect_container():
 	recollect_container.visible = true
+	# Ocultar el Bowl (Isaac con bowl)
+	var bowl = recollect_container.get_node_or_null("Bowl")
+	if bowl:
+		bowl.visible = false
 
 func fill_ingredients_textrect(instance: Node) -> void:
 	if not instance:
@@ -194,69 +199,113 @@ func create_ingredient_physics(ingredient_id: String) -> Area2D:
 	if not ResourceLoader.exists(path): return null
 
 	var tex = load(path)
-	
+
 	var area = Area2D.new()
 	area.add_to_group("ingredients") # ¡Esto es lo que busca el Bowl!
 	area.set_meta("id", ingredient_id)
-	
+
 	var sprite = Sprite2D.new()
 	sprite.texture = tex
 	sprite.scale = Vector2(0.3, 0.3)
 	area.add_child(sprite)
-	
+
 	var collision = CollisionShape2D.new()
 	var shape = CircleShape2D.new()
 	shape.radius = 30 # Radio de colisión
 	collision.shape = shape
 	area.add_child(collision)
-	
+
 	area.z_index = 1
 	return area
+
+func create_ingredient_clickable(ingredient_id: String) -> Area2D:
+	var path = "res://assets/pastry/ingredients/%s.png" % ingredient_id
+	if not ResourceLoader.exists(path): return null
+
+	var tex = load(path)
+
+	var area = Area2D.new()
+	area.add_to_group("ingredients")
+	area.set_meta("id", ingredient_id)
+	area.input_pickable = true
+
+	var sprite = Sprite2D.new()
+	sprite.texture = tex
+	sprite.scale = Vector2(0.35, 0.35)
+	area.add_child(sprite)
+
+	var collision = CollisionShape2D.new()
+	var shape = CircleShape2D.new()
+	shape.radius = 40
+	collision.shape = shape
+	area.add_child(collision)
+
+	area.z_index = 1
+
+	# Conectar señal de input para detectar clicks
+	area.input_event.connect(_on_ingredient_area_clicked.bind(area, ingredient_id))
+
+	return area
+
+func _on_ingredient_area_clicked(_viewport: Node, event: InputEvent, _shape_idx: int, area: Area2D, ing_id: String) -> void:
+	if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
+		AudioManager.play_collect_ingredient_sfx()
+		GlobalManager.collected_ingredients.append(ing_id)
+
+		# Animacion de recoleccion
+		var tween = create_tween()
+		tween.tween_property(area, "scale", Vector2(1.3, 1.3), 0.1)
+		tween.tween_property(area, "modulate:a", 0.0, 0.15)
+		tween.tween_callback(area.queue_free)
+
+		# Habilitar boton de preparar
+		check_prepare_button()
 	
 func animate_ingredients(ingr_loop: Array) -> void:
-	print("🥣 INICIO CAÍDA FÍSICA: ", ingr_loop)
+	print("🥣 INICIO MOVIMIENTO HORIZONTAL: ", ingr_loop)
 	var container := recollect_container
-	
-	
+
+	# Ocultar el Bowl (Isaac)
+	var bowl = container.get_node_or_null("Bowl")
+	if bowl:
+		bowl.visible = false
+
 	clear_children_except_bowl(container)
 
-	
-	var start_y := -100.0
-	var end_y := container.size.y + 150.0
-	var min_x := 50.0
-	var max_x := container.size.x - 50.0
-	var duration := 3.0
-	var spawn_interval := 0.8
+	# Movimiento horizontal de derecha a izquierda
+	var viewport_size = get_viewport().get_visible_rect().size
+	var start_x: float = viewport_size.x + 100.0
+	var end_x: float = -150.0
+	var table_y: float = 500.0  # Altura sobre la mesa
+	var duration: float = 5.0
+	var spawn_interval: float = 0.9
 
 	for i in range(ingr_loop.size()):
 		var ing_id = ingr_loop[i]
-		
-	
-		var new_ing = create_ingredient_physics(ing_id)
+
+		var new_ing = create_ingredient_clickable(ing_id)
 		if not new_ing: continue
-		
+
 		container.add_child(new_ing)
-		
 
-		
-		var random_x = randf_range(min_x, max_x)
-		new_ing.position = Vector2(random_x, start_y)
+		# Posicion vertical con pequeña variacion aleatoria
+		var random_y = table_y + randf_range(-30.0, 30.0)
+		new_ing.position = Vector2(start_x, random_y)
 
-	
 		var tween := create_tween()
-		tween.tween_property(new_ing, "position:y", end_y, duration) \
+		tween.tween_property(new_ing, "position:x", end_x, duration) \
 			.set_trans(Tween.TRANS_LINEAR) \
 			.set_delay(spawn_interval * i)
-			
+
 		tween.tween_callback(Callable(new_ing, "queue_free"))
 		active_tweens.append(tween)
-	
-		
+
 		if i == ingr_loop.size() - 1:
 			tween.finished.connect(func():
+				print("⚠️ OVERLAY: Último tween terminado, emitiendo timeout")
 				hide_recollect_container()
 				btn_prepare.visible = false
-				
+
 				emit_signal("ingredients_minigame_timeout")
 			)
 			
@@ -357,29 +406,50 @@ func _on_btn_back_pressed() -> void:
 
 func _on_btn_continue_pressed() -> void:
 	AudioManager.play_click_sfx()
+
+	# Preparar datos de la receta
+	emit_signal("ingredients_minigame_started")
+	minigame_started = true
+	var recipe_selected = GlobalManager.current_level_recipes[GlobalManager.selected_recipe_idx]
+	GlobalManager.selected_recipe_data = recipe_selected
+
+	var array_size = GlobalManager.ingredientes_array_size
+	var ingredients = recipe_selected["ingredients"]
+	var ingr_loop = generate_arr(ingredients, array_size)
+
+	# Ocultar containers del overlay
 	hide_recipe_container()
 	hide_menu_container()
-	show_recollect_container()
-	start_ingredient_minigame()
-	
+
+	# Emitir señal para que el nivel muestre los ingredientes
+	emit_signal("recipe_selected", recipe_selected, ingr_loop)
+
+	# Mostrar el menu de ingredientes (receta pequeña)
 	var instance = show_ingredients_textrect()
 	fill_ingredients_textrect(instance)
+
+	# Mostrar boton de preparar (deshabilitado hasta que seleccione ingredientes)
+	btn_prepare.visible = true
+	btn_prepare.disabled = true
 	
 func _on_btn_prepare_recipe_pressed() -> void:
 	AudioManager.play_click_sfx()
 	AudioManager.stop_newton_humming_sfx()
 	GlobalManager.recipe_started = true
-	
+
 	if minigame_started:
-		 
 		for t in active_tweens:
 			if is_instance_valid(t):
 				t.kill()
 		active_tweens.clear()
-		
-		
+
 		clear_children(recollect_container)
-		
+
+		# Detener ingredientes en el nivel principal
+		var level = get_tree().get_first_node_in_group("levels")
+		if level and level.has_method("stop_ingredients_minigame"):
+			level.stop_ingredients_minigame()
+
 		minigame_started = false
 		btn_prepare.visible = false
 		GameController.make_newton_cook()

--- a/sandagamejam/scripts/levels/pastry_level_1.gd
+++ b/sandagamejam/scripts/levels/pastry_level_1.gd
@@ -2,6 +2,7 @@
 extends Node2D
 
 signal level_cleared
+signal ingredients_timeout
 
 @onready var characters = $Personajes
 @onready var customer_scene := preload("res://scenes/characters/Customer.tscn")
@@ -14,6 +15,13 @@ var current_customer: Node2D = null
 
 var center_frac_x := 0.5 # 0.25 cuando se abra el minijuego
 var original_viewport_size: Vector2
+
+# Variables para ingredientes en la mesa
+var active_ingredients: Array = []
+var active_tweens: Array = []
+var ingredients_container: Node2D = null
+var prepare_button: Button = null
+var minigame_active: bool = false
 
 # Escena del nivel base
 func _ready():
@@ -142,3 +150,196 @@ func print_combos(combos):
 	for comb in combos:
 		print("Personaje: ", comb["character_id"], "\nEstado: ", comb["mood_id"], "\nTexto: ", comb["texts"][GlobalManager.game_language])
 		print("......")
+
+# ============ INGREDIENTES EN LA MESA ============
+
+func start_ingredients_on_table(recipe_data: Dictionary, ingr_loop: Array) -> void:
+	print("🍳 Iniciando ingredientes en la mesa: ", ingr_loop)
+	print("🍳 Cantidad de ingredientes: ", ingr_loop.size())
+
+	# Crear contenedor si no existe
+	if not ingredients_container:
+		ingredients_container = Node2D.new()
+		ingredients_container.name = "IngredientsContainer"
+		ingredients_container.z_index = 5
+		ingredients_container.process_mode = Node.PROCESS_MODE_ALWAYS
+		add_child(ingredients_container)
+		print("📦 Contenedor creado, en árbol: ", ingredients_container.is_inside_tree())
+
+	# Limpiar ingredientes anteriores
+	clear_ingredients()
+
+	# Configuracion del movimiento horizontal (de izquierda a derecha)
+	var viewport_size = get_viewport().get_visible_rect().size
+	var start_x: float = -100.0  # Empieza desde la izquierda (fuera de pantalla)
+	var end_x: float = viewport_size.x + 100.0  # Sale por la derecha
+	var table_y: float = 540.0  # Sobre la mesa
+	var duration: float = 5.0
+	var spawn_interval: float = 0.7
+	print("📐 start_x: ", start_x, " end_x: ", end_x)
+
+	var ingredients_created = 0
+	for i in range(ingr_loop.size()):
+		var ing_id = ingr_loop[i]
+
+		var ingredient = create_clickable_ingredient(ing_id)
+		if not ingredient:
+			print("❌ No se pudo crear ingrediente: ", ing_id)
+			continue
+
+		ingredients_container.add_child(ingredient)
+		active_ingredients.append(ingredient)
+		ingredients_created += 1
+
+		# Posicion inicial con variacion vertical mas amplia
+		var random_y = table_y + randf_range(-60.0, 40.0)
+		ingredient.position = Vector2(start_x, random_y)
+
+		# Animacion de movimiento horizontal
+		var tween = get_tree().create_tween()
+		tween.bind_node(ingredient)
+		tween.tween_property(ingredient, "position:x", end_x, duration) \
+			.set_trans(Tween.TRANS_LINEAR) \
+			.set_delay(spawn_interval * i)
+		tween.tween_callback(ingredient.queue_free)
+		active_tweens.append(tween)
+
+		if i == 0:
+			print("🎬 Primer tween - delay: 0, duracion: ", duration)
+		if i == ingr_loop.size() - 1:
+			print("🎬 Último tween - delay: ", spawn_interval * i, ", duracion: ", duration)
+
+		# En el ultimo ingrediente, emitir timeout
+		if i == ingr_loop.size() - 1:
+			print("🔗 Conectando timeout al ingrediente #", i, " (último)")
+			tween.finished.connect(func():
+				print("⚠️ NIVEL: Último ingrediente terminó, emitiendo timeout")
+				minigame_active = false
+				if prepare_button and is_instance_valid(prepare_button):
+					prepare_button.queue_free()
+					prepare_button = null
+				emit_signal("ingredients_timeout")
+			)
+
+	print("✅ Ingredientes creados: ", ingredients_created, " de ", ingr_loop.size())
+
+	# Crear botón de preparar
+	minigame_active = true
+	create_prepare_button()
+
+func create_prepare_button() -> void:
+	if prepare_button and is_instance_valid(prepare_button):
+		prepare_button.queue_free()
+
+	prepare_button = Button.new()
+	prepare_button.text = GlobalManager.btn_cook_recipe_label
+	prepare_button.custom_minimum_size = Vector2(200, 60)
+	prepare_button.disabled = true  # Deshabilitado hasta seleccionar ingredientes
+
+	# Posicionar en la parte inferior central
+	var viewport_size = get_viewport().get_visible_rect().size
+	prepare_button.position = Vector2(viewport_size.x / 2 - 100, viewport_size.y - 100)
+
+	# Añadir al UILayer del nivel
+	var ui_layer = $UILayer
+	if ui_layer:
+		ui_layer.add_child(prepare_button)
+	else:
+		add_child(prepare_button)
+
+	prepare_button.pressed.connect(_on_prepare_button_pressed)
+
+func _on_prepare_button_pressed() -> void:
+	if not minigame_active:
+		return
+
+	AudioManager.play_click_sfx()
+	GlobalManager.recipe_started = true
+	minigame_active = false
+
+	# Limpiar ingredientes y botón
+	clear_ingredients()
+	if prepare_button and is_instance_valid(prepare_button):
+		prepare_button.queue_free()
+		prepare_button = null
+
+	# Hacer que Newton cocine
+	GameController.make_newton_cook()
+
+func enable_prepare_button() -> void:
+	if prepare_button and is_instance_valid(prepare_button):
+		prepare_button.disabled = false
+
+func create_clickable_ingredient(ingredient_id: String) -> Area2D:
+	var path = "res://assets/pastry/ingredients/%s.png" % ingredient_id
+	if not ResourceLoader.exists(path):
+		return null
+
+	var tex = load(path)
+
+	var area = Area2D.new()
+	area.add_to_group("ingredients")
+	area.set_meta("id", ingredient_id)
+	area.input_pickable = true
+
+	var sprite = Sprite2D.new()
+	sprite.texture = tex
+	sprite.scale = Vector2(0.4, 0.4)
+	area.add_child(sprite)
+
+	var collision = CollisionShape2D.new()
+	var shape = CircleShape2D.new()
+	shape.radius = 45
+	collision.shape = shape
+	area.add_child(collision)
+
+	area.z_index = 10
+
+	# Conectar click
+	area.input_event.connect(_on_table_ingredient_clicked.bind(area, ingredient_id))
+
+	return area
+
+func _on_table_ingredient_clicked(_viewport: Node, event: InputEvent, _shape_idx: int, area: Area2D, ing_id: String) -> void:
+	if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
+		AudioManager.play_collect_ingredient_sfx()
+		GlobalManager.collected_ingredients.append(ing_id)
+
+		# Animacion de recoleccion
+		var tween = create_tween()
+		tween.tween_property(area, "scale", Vector2(1.5, 1.5), 0.1)
+		tween.tween_property(area, "modulate:a", 0.0, 0.15)
+		tween.tween_callback(area.queue_free)
+
+		# Remover de la lista
+		active_ingredients.erase(area)
+
+		# Habilitar boton de preparar si hay ingredientes seleccionados
+		if GlobalManager.collected_ingredients.size() > 0:
+			enable_prepare_button()
+
+func clear_ingredients() -> void:
+	print("🧹 clear_ingredients llamado - tweens activos: ", active_tweens.size())
+	# Detener tweens
+	for t in active_tweens:
+		if is_instance_valid(t):
+			t.kill()
+	active_tweens.clear()
+
+	# Eliminar ingredientes
+	for ing in active_ingredients:
+		if is_instance_valid(ing):
+			ing.queue_free()
+	active_ingredients.clear()
+
+	# Limpiar contenedor
+	if ingredients_container:
+		for child in ingredients_container.get_children():
+			child.queue_free()
+
+func stop_ingredients_minigame() -> void:
+	minigame_active = false
+	clear_ingredients()
+	if prepare_button and is_instance_valid(prepare_button):
+		prepare_button.queue_free()
+		prepare_button = null

--- a/sandagamejam/scripts/ui/final_screen.gd
+++ b/sandagamejam/scripts/ui/final_screen.gd
@@ -13,6 +13,7 @@ extends Control
 @onready var name_label = $ScoreContainer/Name
 @onready var ranking_container = $RankingContainer
 @onready var play_again_btn = $BtnPlayAgain
+@onready var back_to_menu_btn = $BtnBackToMenu
 @onready var recipe_texture = $Recipe
 @onready var loading_label = $LoadingLabel
 
@@ -106,17 +107,27 @@ func show_final_screen(state: GlobalManager.GameState):
 	
 func show_name_label():
 	var display = ""
-	
+
 	if not add_new_score:
 		name_label.text = display
+		# Si no califica para ranking, mostrar botones directamente
+		show_buttons()
 		return
-	
+
 	for i in range(max_name_length):
 		if i < current_name.size():
 			display += current_name[i] + ""
 		else:
 			display += "_ "
-	name_label.text =  menu_labels["ranking"]["name"] + "\n" + display 
+	name_label.text =  menu_labels["ranking"]["name"] + "\n" + display
+
+func show_buttons():
+	var label = play_again_btn.get_node("Label")
+	label.text = menu_labels["play_again"]
+	var back_label = back_to_menu_btn.get_node("Label")
+	back_label.text = menu_labels.get("back_to_menu", "Menú principal")
+	play_again_btn.visible = true
+	back_to_menu_btn.visible = true 
 	
 
 func animate_loading_label():
@@ -191,10 +202,8 @@ func is_player_in_ranking(score_value: int) -> bool:
 
 func show_ranking():
 	loading_label.visible = false
-	
-	var label = play_again_btn.get_node("Label")
-	label.text = menu_labels["play_again"] 
 	ranking_container.visible = true
+	show_buttons()
 	
 	
 func _on_AnimationPlayer_animation_finished(anim_name):
@@ -207,6 +216,11 @@ func _on_btn_play_again_pressed() -> void:
 	queue_free()
 	AudioManager.play_click_sfx()
 	GameController.reset_game()
+
+func _on_btn_back_to_menu_pressed() -> void:
+	queue_free()
+	AudioManager.play_click_sfx()
+	GameController.load_main_menu()
 	
 func _build_entries() -> void:
 	free_container_children()


### PR DESCRIPTION
## Summary
- Los ingredientes ahora se mueven horizontalmente de izquierda a derecha sobre la mesa
- El usuario hace click para seleccionar ingredientes (ya no usa Isaac con el bowl)
- El overlay se cierra después de seleccionar la receta, mostrando la escena completa
- Se añade botón "Preparar" en el nivel que se habilita al seleccionar ingredientes
- Mejoras en la pantalla final con botón de volver al menú

## Test plan
- [ ] Verificar que los ingredientes aparecen desde la izquierda y se mueven hacia la derecha
- [ ] Verificar que se puede hacer click en los ingredientes para seleccionarlos
- [ ] Verificar que el botón "Preparar" se habilita al seleccionar al menos un ingrediente
- [ ] Verificar que al presionar "Preparar", Newton cocina y se muestra el resultado
- [ ] Verificar que si no se presiona "Preparar" a tiempo, se muestra el mensaje de timeout
- [ ] Verificar que la pantalla final muestra los botones correctamente

🤖 Generated with [Claude Code](https://claude.com/claude-code)